### PR TITLE
User stroy 3 

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -31,6 +31,7 @@ class BulkDiscountsController < ApplicationController
     @bulk_discount = @merchant.bulk_discounts.find(params[:id])
     @bulk_discount.destroy
     redirect_to [@merchant, :bulk_discounts]
+    flash[:notice] = "Discount #{params[:id]} was deleted"
   end
 end
 

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -25,6 +25,13 @@ class BulkDiscountsController < ApplicationController
       render :new
     end 
   end
+
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+    @bulk_discount.destroy
+    redirect_to [@merchant, :bulk_discounts]
+  end
 end
 
 

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -4,7 +4,7 @@
 <br>
 <%@bulk_discounts.each do |discount|%>
     <div id=discounts-<%=discount.id%>>
-      <p> Discount: <%=(discount.percentage_discount ) * 100%>% | Quantity Threshold: <%=discount.quantity_threshold%> | <%= link_to "#{discount.id} Discount's Page",  merchant_bulk_discount_path(@merchant, discount), method: :get %> </p>
+      <p> Discount: <%=(discount.percentage_discount ) * 100%>% | Quantity Threshold: <%=discount.quantity_threshold%> | <%= link_to "Discount ##{discount.id}'s Page",  merchant_bulk_discount_path(@merchant, discount), method: :get %> </p>
       <p><%= button_to "Delete Discount", merchant_bulk_discount_path(@merchant, discount), method: :delete%>
     </div>
 <%end%>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -4,6 +4,7 @@
 <br>
 <%@bulk_discounts.each do |discount|%>
     <div id=discounts-<%=discount.id%>>
-      <p> Discount: <%=(discount.percentage_discount ) * 100%>% | Quantity Threshold: <%=discount.quantity_threshold%> | <%= link_to "#{discount.id} Discount Page",  merchant_bulk_discount_path(@merchant, discount), method: :get %> </p>
+      <p> Discount: <%=(discount.percentage_discount ) * 100%>% | Quantity Threshold: <%=discount.quantity_threshold%> | <%= link_to "#{discount.id} Discount's Page",  merchant_bulk_discount_path(@merchant, discount), method: :get %> </p>
+      <p><%= button_to "Delete Discount", merchant_bulk_discount_path(@merchant, discount), method: :delete%>
     </div>
 <%end%>

--- a/spec/features/bulk_discount/index_spec.rb
+++ b/spec/features/bulk_discount/index_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Merchant Bulk Discounts Index" do
 
       it "Each bulk discount listed includes a link to its show page" do
         within("#discounts-#{@discount1.id}") do
-          expect(page).to have_link("#{@discount1.id} Discount's Page")
-          click_link("#{@discount1.id} Discount's Page")
+          expect(page).to have_link("Discount ##{@discount1.id}'s Page")
+          click_link("Discount ##{@discount1.id}'s Page")
           expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount1))
         end
       end
@@ -50,7 +50,7 @@ RSpec.describe "Merchant Bulk Discounts Index" do
           click_button("Delete Discount")
           expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
         end
-        expect(page).to_not have_content(@discount1.id)
+        expect(page).to_not have_content("Discount ##{@discount1.id}'s Page")
       end
     end
   end

--- a/spec/features/bulk_discount/index_spec.rb
+++ b/spec/features/bulk_discount/index_spec.rb
@@ -29,18 +29,28 @@ RSpec.describe "Merchant Bulk Discounts Index" do
         end 
       end
 
-      it "And each bulk discount listed includes a link to its show page" do
+      it "Each bulk discount listed includes a link to its show page" do
         within("#discounts-#{@discount1.id}") do
-          expect(page).to have_link("#{@discount1.id} Discount Page")
-          click_link("#{@discount1.id} Discount Page")
+          expect(page).to have_link("#{@discount1.id} Discount's Page")
+          click_link("#{@discount1.id} Discount's Page")
           expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount1))
         end
       end
       #user story 2
-      it "Then I see a link to create a new discount" do 
+      it " I see a link to create a new discount" do 
         expect(page).to have_button("New Discount")
         click_button("New Discount")
         expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
+      end
+      #user story 3
+      it " Then next to each bulk discount I see a link to delete it " do
+        
+        within("#discounts-#{@discount1.id}") do
+          expect(page).to have_button("Delete Discount")
+          click_button("Delete Discount")
+          expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+        end
+        expect(page).to_not have_content(@discount1.id)
       end
     end
   end

--- a/spec/features/bulk_discount/new_spec.rb
+++ b/spec/features/bulk_discount/new_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Merchant Bulk Discount New" do
   before :each do
     @merchant1 = Merchant.create!(name: 'Dudes Haberdashery')
   end
-
+  #user story 2 
   describe "As a merchant" do 
     describe " When I click the new discount button" do 
       describe " Then I am taken to a new page where I see a form to add a new bulk discount" do 
@@ -30,7 +30,20 @@ RSpec.describe "Merchant Bulk Discount New" do
                 expect(page).to have_content("Discount: 30.0%")
                 expect(page).to have_content("Quantity Threshold: 15")
               end 
-              
+            end
+            it " Validates that the form is created properly before saving" do
+              visit merchant_bulk_discounts_path(@merchant1)
+              expect(page). to have_button("New Discount")
+              click_button("New Discount")
+              expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
+
+              expect(page).to have_field(:percentage_discount)
+              expect(page).to have_field(:quantity_threshold)
+
+              fill_in :percentage_discount, with: ""
+              fill_in :quantity_threshold, with: 15
+              click_button("Add Discount")
+              expect(page) have_content("Percentage discount can't be blank")
             end
           end
         end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed