### PR TITLE
User Story 5 

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -21,9 +21,27 @@ class BulkDiscountsController < ApplicationController
       flash[:notice] = "Bulk discount created successfully"
       redirect_to [@merchant, :bulk_discounts]
     else 
-     flash[:notice] =  bulk_discount.errors.full_messages
+     flash[:notice] = bulk_discount.errors.full_messages
       render :new
     end 
+  end
+
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    bulk_discount = @merchant.bulk_discounts.find(params[:id])
+    bulk_discount.update(bulk_discount_params)
+    if bulk_discount.save
+      redirect_to [@merchant, :bulk_discount]
+      flash[:notice] = "Discount ##{params[:id]} updated"
+    else
+      flash[:notice] = bulk_discount.errors.full_messages
+      redirect_to edit_merchant_bulk_discount_path(@merchant, bulk_discount)
+    end
   end
 
   def destroy

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,7 @@
+<%= form_with url: merchant_bulk_discount_path(@merchant, @bulk_discount), method: :patch, local: true do |f|%>
+  <%= f.label :percentage_discount, "Discount Percentage"%>
+  <%= f.number_field :percentage_discount, min: 0, max: 1, step: 0.01, value: @bulk_discount.percentage_discount, require: true %>
+  <%= f.label :quantity_threshold, "Quantity" %>
+  <%= f.number_field :quantity_threshold, min: 0, value: @bulk_discount.quantity_threshold , required: true %>
+  <%= f.submit "Update Discount" %>
+<% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,4 +1,4 @@
 <h1><%=@merchant.name%>'s discount #<%=@bulk_discount.id%></h1>
 <br>
 <h3> Discount: <%=(@bulk_discount.percentage_discount ) * 100%>% | Quantity Threshold: <%=@bulk_discount.quantity_threshold%></h3>
-<%= button_to "Edit Discount", edit_merchant_bulk_discount(@merchant, @bulk_discount), method: :get, local: true %>
+<%= button_to "Edit Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount), method: :get, local: true %>

--- a/spec/features/bulk_discount/edit_spec.rb
+++ b/spec/features/bulk_discount/edit_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper' 
+
+
+RSpec.describe "Merchant Bulk Discount edit" do 
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Dudes Haberdashery')
+    @discount1 = @merchant1.bulk_discounts.create!(percentage_discount: 0.20 ,quantity_threshold: 10)
+  end
+  #user story 5 
+  describe "As a merchant" do 
+    describe "When I visit my edit discount form page" do 
+      describe "I see that the discounts current attributes are pre-poluated in the form" do 
+        describe "When I change any/all of the information and click submit" do
+          describe "Then I am redirected to the bulk discount's show page" do 
+            it "And I see that the discount's attributes have been updated" do 
+              visit edit_merchant_bulk_discount_path(@merchant1, @discount1)
+              
+              expect(page).to have_field(:percentage_discount, with: '0.2')
+
+              expect(page).to have_field(:quantity_threshold, with: '10')
+
+              fill_in :percentage_discount, with: "0.30" 
+              fill_in :quantity_threshold, with: "15"
+              click_button "Update Discount"
+
+              expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount1))
+              
+              expect(page).to have_content("Discount: 30.0%")
+              expect(page).to have_content("Quantity Threshold: 15")
+
+            end
+            
+            it "Validates that the form is created properly before saving " do
+              visit edit_merchant_bulk_discount_path(@merchant1, @discount1)
+              
+              expect(page).to have_field(:percentage_discount, with: '0.2')
+
+              expect(page).to have_field(:quantity_threshold, with: '10')
+
+              fill_in :percentage_discount, with: "" 
+              fill_in :quantity_threshold, with: "2"
+              click_button "Update Discount"
+              save_and_open_page
+              expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount1))
+              expect(page).to have_content("Percentage discount can't be blank")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated